### PR TITLE
Add file hashing task

### DIFF
--- a/TEx/hash_files.py
+++ b/TEx/hash_files.py
@@ -1,0 +1,62 @@
+"""Utility to compute file hashes for verification purposes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from typing import Dict
+
+_EXCLUDE_DIRS = {'.git', '.venv', '__pycache__'}
+
+
+def _hash_file(path: str, algorithm: str) -> str:
+    """Return the file hash using the selected algorithm."""
+    if algorithm.lower() == 'md5':
+        hasher = hashlib.md5()
+    else:
+        hasher = hashlib.sha256()
+
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def hash_directory(directory: str, algorithm: str = 'sha256') -> Dict[str, str]:
+    """Return a mapping from relative file paths to hashes."""
+    hashes: Dict[str, str] = {}
+    for root, dirs, files in os.walk(directory):
+        dirs[:] = [d for d in dirs if d not in _EXCLUDE_DIRS]
+        for file in files:
+            file_path = os.path.join(root, file)
+            rel_path = os.path.relpath(file_path, directory)
+            hashes[rel_path] = _hash_file(file_path, algorithm)
+    return hashes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Compute and store file hashes.')
+    parser.add_argument('-d', '--directory', default='.', help='Directory to scan')
+    parser.add_argument(
+        '-a', '--algorithm', choices=['md5', 'sha256'], default='sha256',
+        help='Hash algorithm to use'
+    )
+    parser.add_argument(
+        '-o', '--output', default='file_hashes.json',
+        help='Output file to store the hashes'
+    )
+    args = parser.parse_args()
+
+    base_dir = os.path.abspath(args.directory)
+    hashes = hash_directory(base_dir, args.algorithm)
+
+    with open(args.output, 'w') as f:
+        json.dump(hashes, f, indent=2)
+
+    print(f'Wrote {len(hashes)} hashes to {args.output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Repository: [https://github.com/guibacellar/TEx](https://github.com/guibacellar/
 - Elastic Search 8+ Native Integration
 - Image OCR using Tesseract
 - Signals for Helping Monitoring
+- File Hashing task for integrity verification
 
 <!-- LIMITATIONS -->
 ## Know Limitations

--- a/docs/maintenance/hash_files.md
+++ b/docs/maintenance/hash_files.md
@@ -1,0 +1,11 @@
+# Maintenance - File Hashing
+
+Telegram Explorer includes a helper task to compute the SHA256 (or MD5) hash of every file in a directory. The generated table can be used to detect duplicates, validate integrity in the future and create unique identifiers for traceability.
+
+## Usage
+
+```bash
+python3 -m TEx.hash_files --directory PATH_TO_SCAN --algorithm sha256 --output file_hashes.json
+```
+
+The command scans the directory recursively, ignoring common virtual environment and Git folders, and stores the hashes in the chosen output file.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - 'Text Report': 'report/report_text.md'
   - 'Maintenance':
       - 'Purging Old Data': 'maintenance/purge_old_data.md'
+      - 'File Hashing': 'maintenance/hash_files.md'
   - 'Changelog':
       - 'V0.3.0': 'changelog/v030.md'
 

--- a/tests/test_hash_files.py
+++ b/tests/test_hash_files.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+from hashlib import sha256
+
+from TEx.hash_files import hash_directory
+
+
+def test_hash_directory_creates_hashes(tmp_path):
+    file1 = tmp_path / "a.txt"
+    file2 = tmp_path / "b.txt"
+
+    file1.write_text("hello")
+    file2.write_text("world")
+
+    hashes = hash_directory(str(tmp_path), "sha256")
+
+    expected1 = sha256(b"hello").hexdigest()
+    expected2 = sha256(b"world").hexdigest()
+
+    rel1 = os.path.relpath(file1, tmp_path)
+    rel2 = os.path.relpath(file2, tmp_path)
+
+    assert hashes[rel1] == expected1
+    assert hashes[rel2] == expected2


### PR DESCRIPTION
## Summary
- create `hash_files.py` tool for computing file hashes
- document new maintenance task
- reference file hashing task in the docs index and mkdocs menu
- add unit test for the hashing helper

## Testing
- `pytest tests/test_hash_files.py -q`
- `pytest -q` *(fails: numpy.dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_6841ecc06e1c832a8e76c3ff852f9e48